### PR TITLE
add support for unbinding PCI device drivers

### DIFF
--- a/setup_open_vswitch/check.py
+++ b/setup_open_vswitch/check.py
@@ -28,49 +28,68 @@ def configuration_check(config):
     :param config: The configuration which describes the OVS setup
     """
     logging.info("Checking configuration")
-    if type(config) != list:
+    if type(config) != dict:
         raise SetupOVSConfigException(
-            "The configuration should be a bridge list"
+            "The configuration should be a dictionary"
         )
-    for bridge in config:
-        if type(bridge) != dict:
-            raise SetupOVSConfigException("A bridge must be a dictionary")
-        if "name" not in bridge:
-            raise SetupOVSConfigException("Bridge without name attribute")
-        logging.debug("Checking: " + bridge["name"])
-        if "ports" in bridge:
-            if type(bridge["ports"]) != list:
-                raise SetupOVSConfigException("ports must be a list")
-            for port in bridge["ports"]:
-                if type(port) != dict:
-                    raise SetupOVSConfigException(
-                        "A port must be a dictionary"
-                    )
-                _check_port_configuration(bridge["name"], port)
-        if "other_config" in bridge:
-            attribute_value = (
-                [bridge["other_config"]]
-                if type(bridge["other_config"]) == str
-                else bridge["other_config"]
+    if "bridges" in config:
+        if type(config["bridges"]) != list:
+            raise SetupOVSConfigException(
+                "bridges configuration should be a list"
             )
-            if type(attribute_value) != list:
-                raise SetupOVSConfigException(
-                    "Bridge {}: other_config must be an string or a "
-                    "strings list".format(bridge["name"])
+        for bridge in config["bridges"]:
+            if type(bridge) != dict:
+                raise SetupOVSConfigException("A bridge must be a dictionary")
+            if "name" not in bridge:
+                raise SetupOVSConfigException("Bridge without name attribute")
+            logging.debug("Checking: " + bridge["name"])
+            if "ports" in bridge:
+                if type(bridge["ports"]) != list:
+                    raise SetupOVSConfigException("ports must be a list")
+                for port in bridge["ports"]:
+                    if type(port) != dict:
+                        raise SetupOVSConfigException(
+                            "A port must be a dictionary"
+                        )
+                    _check_port_configuration(bridge["name"], port)
+            if "other_config" in bridge:
+                attribute_value = (
+                    [bridge["other_config"]]
+                    if type(bridge["other_config"]) == str
+                    else bridge["other_config"]
                 )
-            for element in attribute_value:
-                if type(element) != str:
+                if type(attribute_value) != list:
                     raise SetupOVSConfigException(
                         "Bridge {}: other_config must be an string or a "
                         "strings list".format(bridge["name"])
                     )
-        for attribute in ("rstp_enable", "enable_ipv6"):
-            if attribute in bridge and type(bridge[attribute]) != bool:
-                raise SetupOVSConfigException(
-                    "Bridge {}: {} must be a boolean".format(
-                        bridge["name"], attribute
+                for element in attribute_value:
+                    if type(element) != str:
+                        raise SetupOVSConfigException(
+                            "Bridge {}: other_config must be an string or a "
+                            "strings list".format(bridge["name"])
+                        )
+            for attribute in ("rstp_enable", "enable_ipv6"):
+                if attribute in bridge and type(bridge[attribute]) != bool:
+                    raise SetupOVSConfigException(
+                        "Bridge {}: {} must be a boolean".format(
+                            bridge["name"], attribute
+                        )
                     )
+    if "unbind_pci_address" in config:
+        if type(config["unbind_pci_address"]) != list:
+            raise SetupOVSConfigException(
+                "unbind_pci_address should be a PCI addresses list"
+            )
+
+        for pci_address in config["unbind_pci_address"]:
+            if type(pci_address) != str:
+                raise SetupOVSConfigException("A pci_address must be a string")
+            if not helpers.KERNEL_PCI_ADDRESS_MATCHER.match(pci_address):
+                raise SetupOVSConfigException(
+                    f"{pci_address} is not a PCI address"
                 )
+
     logging.info("Configuration check: OK")
 
 

--- a/setup_open_vswitch/helpers.py
+++ b/setup_open_vswitch/helpers.py
@@ -10,6 +10,8 @@ PCI_ADDRESS_MATCHER = re.compile(
     r"(?P<part3>[0-9a-f]))$"
 )
 
+KERNEL_PCI_ADDRESS_MATCHER = re.compile(r"[0-9]{4}:[0-9]{2}:[0-9]{2}\.[0-9]")
+
 IPv4_ADDRESS_MATCHER = re.compile(r"^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$")
 
 MAC_ADDRESS_MATCHER = re.compile(r"^([0-9a-f][0-9a-f]:){5}([0-9a-f][0-9a-f])$")

--- a/setup_open_vswitch/openflow.py
+++ b/setup_open_vswitch/openflow.py
@@ -15,7 +15,9 @@ class SetupOpenFlow:
         SetupOpenFlow constructor
         :param config: the configuration which describes the OVS setup
         """
-        for bridge in config:
+        if "bridges" not in config:
+            return
+        for bridge in config["bridges"]:
             self.configure_bridge_flow(bridge)
 
     @classmethod

--- a/setup_ovs.py
+++ b/setup_ovs.py
@@ -71,6 +71,12 @@ if __name__ == "__main__":
         action="store_true",
         required=False,
     )
+    parser.add_argument(
+        "--no-unbind",
+        help="Do not unbind PCI devices",
+        action="store_true",
+        required=False,
+    )
     args = parser.parse_args()
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -101,6 +107,8 @@ if __name__ == "__main__":
             ovs.clear_ovs()
         if not args.no_remove_interfaces:
             ovs.clear_tap()
+        if not args.no_unbind:
+            ovs.unbind_pci(config)
         if not args.no_ovs:
             ovs.setup_ovs(config)
         if not args.no_openflow:


### PR DESCRIPTION
Before to be able to use DPDK with a NIC, all PCI devices in the same IOMMU group as the NIC we want to use for DPDK as to be unbound (or bind to the vfio_pci driver).

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>