### PR TITLE
Ignore the cluster network (team0)

### DIFF
--- a/setup_open_vswitch/ovs.py
+++ b/setup_open_vswitch/ovs.py
@@ -65,10 +65,11 @@ def setup_ovs(config):
     logging.info("Applying configuration: done")
 
 
-def clear_ovs():
+def clear_ovs(config):
     """
-    Remove all OVS bridges
+    Remove all OVS bridges except the ones listed in the configuration object "ignored_bridges"
     """
+
     list_br = []
     if not helpers.dry_run:
         raw_list_br = helpers.run_command(
@@ -79,6 +80,9 @@ def clear_ovs():
             if raw_list_br.stdout
             else []
         )
+        if "ignored_bridges" in config and config["ignored_bridges"] != []:
+            for ignored_bridge in config["ignored_bridges"]:
+                list_br.remove(ignored_bridge)
     for bridge in list_br:
         if bridge:
             helpers.run_command("/usr/bin/ovs-vsctl", "del-br", bridge)

--- a/setup_ovs.py
+++ b/setup_ovs.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     if not args.check:
         check.system_check()
         if not args.no_remove_bridges:
-            ovs.clear_ovs()
+            ovs.clear_ovs(config)
         if not args.no_remove_interfaces:
             ovs.clear_tap()
         if not args.no_unbind:


### PR DESCRIPTION
OVS is used for 2 things:
- the VM network topology
- the cluster network (needed to enjoy RSTP, not available on standard linux bridges)

It's annoying that when changing the ovs VM topology, all bridges are destroyed and created again. This creates connectivity problem for ceph and corosync, can trigger fencing events, etc.

I propose to make this tool ignore the cluster network configuration "team0", that we will create independantly with ansible.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>