### PR TITLE
Make setup_ovs ignores some taps

### DIFF
--- a/setup_ovs.py
+++ b/setup_ovs.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         if not args.no_remove_bridges:
             ovs.clear_ovs(config)
         if not args.no_remove_interfaces:
-            ovs.clear_tap()
+            ovs.clear_tap(config)
         if not args.no_unbind:
             ovs.unbind_pci(config)
         if not args.no_ovs:


### PR DESCRIPTION
Some taps can be created by networkd, in which case we need setup_ovs to ignore them (by default it clears everything). We create a config item for this "ignored_taps", just like we did for ignored_briges.