### PR TITLE
add port: allow the ofport_request option

### DIFF
--- a/setup_open_vswitch/ovs.py
+++ b/setup_open_vswitch/ovs.py
@@ -253,6 +253,14 @@ def _create_bridges(config, dpdk_bridges):
                             port_name,
                             "external-ids:" + external_id,
                         ]
+                if "ofport_request" in port:
+                    cmd_args += [
+                        "--",
+                        "set",
+                        "Interface",
+                        port_name,
+                        "ofport_request=" + str(port["ofport_request"]),
+                    ]
                 helpers.run_command(*cmd_args)
                 if "other_config" in port:
                     logging.info(


### PR DESCRIPTION
When setting up openflow rules based on incoming port, we need to know the openflow port number ("ofport") value, which is decided at port creation time. 
Since the rules will use a fixed ofport, we need to fix the ofport for the ports we need openflow on. 
OVS has the "ofport_request" option for this purpose.
This commit allows the seapath user to define the ofport_request value for a port in its OVS inventory, and it will be configured as requested at port creation.