### PR TITLE
dpdk: don't bind dpdk if dpdk not used

### DIFF
--- a/setup_ovs/ovs.py
+++ b/setup_ovs/ovs.py
@@ -42,6 +42,7 @@ def setup_ovs(config):
             ".",
             "other_config:dpdk-init=true",
         )
+        _bind_dpdk_interfaces(dpdk_interfaces)
     else:
         logging.info("Disable IOMMU vhost")
         helpers.run_command(
@@ -59,7 +60,6 @@ def setup_ovs(config):
             ".",
             "other_config:dpdk-init=false",
         )
-    _bind_dpdk_interfaces(dpdk_interfaces)
     _create_bridges(config["bridges"], dpdk_bridges)
 
     logging.info("Applying configuration: done")


### PR DESCRIPTION
On non dpdk ovs setup, setup_ovs script crashed with:

Jun 18 12:35:27 ci132 systemd[1]: Starting seapath-config_ovs.service - "Configure OVS bridges and ports"...
Jun 18 12:35:27 ci132 ovs-vsctl[69270]: ovs|00001|vsctl|INFO|Called as /usr/bin/ovs-vsctl set Open_vSwitch . other_config:vhost-iommu-support=false
Jun 18 12:35:27 ci132 ovs-vsctl[69271]: ovs|00001|vsctl|INFO|Called as /usr/bin/ovs-vsctl set Open_vSwitch . other_config:dpdk-init=false
Jun 18 12:35:27 ci132 setup_ovs[69267]: Traceback (most recent call last):
Jun 18 12:35:27 ci132 setup_ovs[69267]:   File "/usr/local/bin/setup_ovs", line 8, in <module>
Jun 18 12:35:27 ci132 setup_ovs[69267]:     sys.exit(main())
Jun 18 12:35:27 ci132 setup_ovs[69267]:              ~~~~^^
Jun 18 12:35:27 ci132 setup_ovs[69267]:   File "/usr/local/lib/python3.13/dist-packages/setup_ovs/setup_ovs.py", line 117, in main
Jun 18 12:35:27 ci132 setup_ovs[69267]:     ovs.setup_ovs(config)
Jun 18 12:35:27 ci132 setup_ovs[69267]:     ~~~~~~~~~~~~~^^^^^^^^
Jun 18 12:35:27 ci132 setup_ovs[69267]:   File "/usr/local/lib/python3.13/dist-packages/setup_ovs/ovs.py", line 62, in setup_ovs
Jun 18 12:35:27 ci132 setup_ovs[69267]:     _bind_dpdk_interfaces(dpdk_interfaces)
Jun 18 12:35:27 ci132 setup_ovs[69267]:     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
Jun 18 12:35:27 ci132 setup_ovs[69267]:   File "/usr/local/lib/python3.13/dist-packages/setup_ovs/ovs.py", line 128, in _bind_dpdk_interfaces
Jun 18 12:35:27 ci132 setup_ovs[69267]:     dpdk_devbind = helpers.find_command("dpdk-devbind", *_DPDK_DEVBIND_CANDIDATES)